### PR TITLE
Fix Kholdstare placement rules

### DIFF
--- a/app/Region/Standard/GanonsTower.php
+++ b/app/Region/Standard/GanonsTower.php
@@ -147,13 +147,6 @@ class GanonsTower extends Region
      */
     public function canPlaceBoss(Boss $boss, string $level = 'top'): bool
     {
-        if (
-            $this->name != "Ice Palace" && $this->world->config('mode.weapons') == 'swordless'
-            && $boss->getName() == 'Kholdstare'
-        ) {
-            return false;
-        }
-
         if ($level == 'top') {
             return !in_array($boss->getName(), [
                 "Agahnim",

--- a/app/Region/Standard/SkullWoods.php
+++ b/app/Region/Standard/SkullWoods.php
@@ -79,13 +79,6 @@ class SkullWoods extends Region
      */
     public function canPlaceBoss(Boss $boss, string $level = 'top'): bool
     {
-        if (
-            $this->name != "Ice Palace" && $this->world->config('mode.weapons') == 'swordless'
-            && $boss->getName() == 'Kholdstare'
-        ) {
-            return false;
-        }
-
         return !in_array($boss->getName(), [
             "Agahnim",
             "Agahnim2",

--- a/app/Region/Standard/TowerOfHera.php
+++ b/app/Region/Standard/TowerOfHera.php
@@ -72,13 +72,6 @@ class TowerOfHera extends Region
      */
     public function canPlaceBoss(Boss $boss, string $level = 'top'): bool
     {
-        if (
-            $this->name != "Ice Palace" && $this->world->config('mode.weapons') == 'swordless'
-            && $boss->getName() == 'Kholdstare'
-        ) {
-            return false;
-        }
-
         return !in_array($boss->getName(), [
             "Agahnim",
             "Agahnim2",


### PR DESCRIPTION
Remove rules that prevent Kholdstare from being placed in GT / Hera / SW in swordless mode.

These rules occasionally cause an infinite loop in boss placement.